### PR TITLE
Removed ng from nginx as we updated nginx formula

### DIFF
--- a/nginx-shibboleth/install.sls
+++ b/nginx-shibboleth/install.sls
@@ -1,7 +1,7 @@
 {% from "nginx-shibboleth/map.jinja" import nginx_shibboleth with context %}
 
 include:
-  - nginx.ng
+  - nginx
   - .service
 
 {% if salt.grains.get('os_family') == 'RedHat' %}


### PR DESCRIPTION
The following error is being thrown when building new ovs instances:
```
Cannot extend ID 'nginx_configure' in 'base:nginx-shibboleth.install'. It is not part of the high state.
This is likely due to a missing include statement or an incorrectly typed ID.
Ensure that a state with an ID of 'nginx_configure' is available
in environment 'base' and to SLS 'nginx-shibboleth.install'
```
I think that after we upgraded our Nginx formula and removed `ng` from it, this is what causing this error.